### PR TITLE
Add IP geolocation

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,8 @@ var logger = require('morgan');
 var indexRouter = require('./routes/index');
 var apiRouter = require('./routes/api');
 
+const ipApi = require('./integrations/ipapi');
+
 var app = express();
 
 const http = require('http').Server(app);
@@ -19,6 +21,15 @@ io.on('connection', function(socket) {
   io.emit('prices', prices);
   io.emit('co2emis', co2emis);
   io.emit('co2emisprog', co2emisprog);
+
+  socket.on('region', function () {
+    // https://stackoverflow.com/questions/11182980/not-getting-remote-address-while-using-proxy-in-socket-io/11187053#11187053
+    const remoteIp = socket.handshake.headers['x-forwarded-for'] || socket.request.connection.remoteAddress;
+    ipApi
+      .getRegion(remoteIp)
+      .then((region) => socket.emit('region', region))
+      .catch((err) => console.error(err))
+  });
 
   socket.on('disconnect', function () {
     io.emit('users', io.engine.clientsCount);

--- a/client/src/data.js
+++ b/client/src/data.js
@@ -94,6 +94,10 @@ socket.on('users', function(data) {
     userCount.set(data);
 });
 
+socket.on('region', function(data) {
+    priceRegion.set(data);
+});
+
 socket.on('prices', function(data) {
     priceData = data;
     calculatePrices();
@@ -110,9 +114,13 @@ socket.on('co2emisprog', function(data) {
 });
 
 priceRegion.subscribe(value => {
-    region = value;
-    calculatePrices();
-    updateCo2Emis();
+    if (typeof value !== 'undefined' && !value) {
+        socket.emit('region');
+    } else {
+        region = value;
+        calculatePrices();
+        updateCo2Emis();
+    }
 });
 
 tax.subscribe((value) => {

--- a/client/src/stores.js
+++ b/client/src/stores.js
@@ -4,10 +4,6 @@ import { tariffs, products } from "./prices.js";
 export const userCount = writable(0);
 
 let storedPriceRegion = localStorage.getItem("priceRegion");
-if (!storedPriceRegion)
-{
-    storedPriceRegion = "DK2";
-}
 export const priceRegion = writable(storedPriceRegion);
 priceRegion.subscribe(value => {
     localStorage.setItem("priceRegion", value);

--- a/integrations/ipapi.js
+++ b/integrations/ipapi.js
@@ -1,0 +1,66 @@
+const http = require('http')
+
+const apiUrl = 'http://ip-api.com/json'
+const defaultRegion = 'DK2'
+
+/*
+    Gets region by IP address by lookup at IP-Api.com for postal code.
+    Postal code >= 5000 DK1, postal code < 5000 DK2.
+    Expect result in 1 sec or will fall back to default region.
+    Rate limit is 45 lookups/min for non-profit - if rate limited,
+    fall back to default region.
+*/
+async function getRegion(ipAddress) {
+    console.log(ipAddress)
+
+    const options = {
+        method: 'GET',
+        timeout: 1000, // in ms
+    }
+
+    return new Promise((resolve, reject) => {
+        const url = `${apiUrl}/${ipAddress}?fields=49186` // fields = status,message,countryCode,zip
+        const req = http.request(url, options, (res) => {
+            if (res.statusCode < 200 || res.statusCode > 299) {
+                return reject(new Error(`HTTP status code ${res.statusCode}`))
+            }
+
+            const body = []
+
+            res.on('data', (chunk) => body.push(chunk))
+
+            res.on('end', () => {
+                const resString = Buffer.concat(body).toString()
+                const res = JSON.parse(resString)
+                console.log(res)
+
+                if (res.status && res.status == 'success' &&
+                    res.countryCode && res.countryCode == 'DK' &&
+                    res.zip && !isNaN(res.zip))
+                {
+                    const region = parseInt(res.zip) >= 5000 ? 'DK1' : 'DK2'
+                    resolve(region)
+                } else {
+                    console.error(new Error(`Fail or invalid response data: ${res.message ?? 'Unknown'}`))
+                    resolve(defaultRegion)
+                }
+            })
+        })
+
+        req.on('error', (err) => {
+            reject(err)
+        })
+
+        req.on('timeout', () => {
+            req.destroy()
+            console.error(new Error('Request time out'))
+            resolve(defaultRegion)
+        })
+
+        req.end()
+    })
+}
+
+module.exports = {
+    getRegion
+}


### PR DESCRIPTION
Adds support for IP geolocation by using https://ip-api.com/.
It uses their free API, that is free for non-profit use, and has a rate limit of 45 lookups/minute.

If a lookup fails, takes more than a second, or we are rate limited, we default to DK2 as region.
Regions are calculated based on zip/postal codes. Postal codes including and above 5000 is designated DK1, and below 5000 as DK2.

Resolves #10 