### PR TITLE
Update prices.js - adding Elektrus

### DIFF
--- a/client/src/prices.js
+++ b/client/src/prices.js
@@ -40,6 +40,12 @@ export const tariffs = [
         name: "Trefor El-Net Øst C",
         normal: .4131,
         peak: 1.1598
+    },
+    {
+        id: "elektrus_c",
+        name: "Elektrus C",
+        normal: .2858,
+        peak: .6461
     }
 ]
 


### PR DESCRIPTION
Prices are only valid to 2022-08-30; must be updated on 2022-10-01.