### PR TITLE
Opdater prices.js for GasEL

### DIFF
--- a/client/src/prices.js
+++ b/client/src/prices.js
@@ -516,9 +516,6 @@ export const products = [
             {
                 name: "Betaling via betalingsservice",
                 amount: 4.656
-            },
-            {
-                name: "Bemærk forudbetaling (aconto)"
             }
         ]
     },


### PR DESCRIPTION
GasEL fakturerer after forbrug, ikke aconto. Det fremgår af https://www.gasel.dk/spoergsmaal-og-svar:

_"Du modtager din første regning måneden efter, at din aftale med Gasel starter. Her vil du blive opkrævet for dit faktiske elforbrug i den måned, der er gået."_