### PR TITLE
Store state of chart series filter

### DIFF
--- a/elspotpris.app/src/routes/stores.js
+++ b/elspotpris.app/src/routes/stores.js
@@ -70,3 +70,9 @@ export const consumption = writable(storedConsumption ? storedConsumption : cons
 consumption.subscribe(value => {
     localStorage.setItem("consumption", value.id);
 });
+
+const storedLegendsEnabled = localStorage.getItem("legendsEnabled");
+export const legendsEnabled = writable(storedLegendsEnabled ? JSON.parse(storedLegendsEnabled) : {}); // Default no filter
+legendsEnabled.subscribe(value => {
+    localStorage.setItem("legendsEnabled", JSON.stringify(value));
+});


### PR DESCRIPTION
Sketchy storing of the chart series filters between site visits.

Related to #30 

This should be future proof, as it makes no assumption of what filters exists on the legend, and just saves whatever is present.
What makes this sketchy is that ApexCharts doesn't allow you to peek at the state of a series, and the only way you can get a read on the state of a series is by toggling the series on and off and read the output.
Their [internal implementation](https://github.com/apexcharts/apexcharts.js/blob/ff248b4a38ee21e993e38ef9a3e1318e59a6ea32/src/modules/Series.js#L30) for getting the state is not pretty to duplicate, so this might be the best way to do it. However, toggling the series is rather expensive in case of performance and brings a bit of a delay, so if a user toggles multiple filters in the legend, there will be a race condition.

So, this is a work in progress. Depending on if the above is a problem or not, then it should be refactored to fix the race condition.