### PR TITLE
Adjust Energi Fyn - SpotEl

### DIFF
--- a/elspotpris.app/src/routes/prices.js
+++ b/elspotpris.app/src/routes/prices.js
@@ -1011,7 +1011,11 @@ export const products = [
                 name: "Spotpris tillæg",
                 amount: 0.045,
                 calculated: true
-            }	
+            },
+	    {
+                name: "Abonnement pr. kWh (Vores Elnet C)",
+		amount: 0.036986,
+	    }
         ],
         fees: [
             {

--- a/elspotpris.app/src/routes/prices.js
+++ b/elspotpris.app/src/routes/prices.js
@@ -1009,13 +1009,9 @@ export const products = [
             },
             {
                 name: "Spotpris tillæg",
-                amount: 0.04,
+                amount: 0.045,
                 calculated: true
-            },
-	    {
-                name: "Abonnement pr. kWh",
-		amount: 0.036,
-	    }			
+            }	
         ],
         fees: [
             {
@@ -1026,7 +1022,12 @@ export const products = [
 	    {
 		name: "MobilePay pr. regning",
 		amount: 2.6
-	    }
+	    },
+	    {
+                name: "Abonnement",
+                amount: 15,
+                paymentsPerYear: 12
+            },
         ]
     }
 ]

--- a/elspotpris.app/src/routes/prices.js
+++ b/elspotpris.app/src/routes/prices.js
@@ -1029,7 +1029,7 @@ export const products = [
 	    },
 	    {
                 name: "Abonnement",
-                amount: 15,
+                amount: 12,
                 paymentsPerYear: 12
             },
         ]

--- a/elspotpris.app/src/routes/prices.js
+++ b/elspotpris.app/src/routes/prices.js
@@ -1009,13 +1009,13 @@ export const products = [
             },
             {
                 name: "Spotpris tillæg",
-                amount: 0.045,
+                amount: 0.04,
                 calculated: true
             },
 	    {
-                name: "Abonnement pr. kWh (Vores Elnet C)",
-		amount: 0.036986,
-	    }
+                name: "Abonnement pr. kWh",
+		amount: 0.036,
+	    }			
         ],
         fees: [
             {


### PR DESCRIPTION
According to https://www.energifyn.dk/privat/el/spotel/ the addition to the spot price is now 4,50 øre/kWh and not 4,00 øre/kWh. Adjust this to reflect the real price. There is also a subscription fee of 15 kr / month. Add that to fees and remove the subscription fee from the kWh price as it seems not to present anymore.

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/2997782/201633374-9bd54b3c-5404-44d9-abcc-7f6806fb37cc.png">

<img width="498" alt="image" src="https://user-images.githubusercontent.com/2997782/201633534-86ae2d2d-1d25-449c-88bd-8ed8a0fbe974.png">

