### PR TITLE
Add Jysk Energi - Min Strøm

### DIFF
--- a/elspotpris.app/src/routes/prices.js
+++ b/elspotpris.app/src/routes/prices.js
@@ -1032,5 +1032,28 @@ export const products = [
                 paymentsPerYear: 12
             },
         ]
-    }
+    },
+    {
+        id: "jysk_energi_min-stroem",
+        name: "Jysk Energi - Min Strøm",
+        link: "https://jyskenergi.dk/el/privat/min-stroem/",
+        payments: "Acontobetaling kvartalsvis",
+        prices: [
+            {
+                name: "Spotpris",
+                amount: null
+            },
+            {
+                name: "Spotpris tillæg",
+                amount: 0.04
+            },
+        ],
+        fees: [
+            {
+                name: "Abonnement",
+                amount: 12,
+                paymentsPerYear: 12
+            },
+        ]
+    },
 ]


### PR DESCRIPTION
Fra deres kundeservice:

Abonnement på forbrug: 15 kroner pr. påbegyndt måned

Din forbrugerstrøm får du også til spotpris med et tillæg på 5 øre/kWh Hertil kommer der så netydelser, skatter og afgifter Moms er inkluderet i alle priser, undtagen produktion.