### PR TITLE
Tilføjet Handelsomkostninger til Clever Power

### DIFF
--- a/elspotpris.app/src/routes/prices.js
+++ b/elspotpris.app/src/routes/prices.js
@@ -827,7 +827,7 @@ export const products = [
             },
             {
                 name: "Fortjeneste, balanceomkostninger, profilomkostninger og handelsomkostninger",
-                amount: 0
+                amount: 0.008
             }
         ],
         fees: [


### PR DESCRIPTION
Tidligere har Clever Power opkræve 0,8 øre i balanceomkostninger, som ikke tidligere har været medtaget her på siden. Nu er Clever blevet pålagt at ændre ordlyden til "Handelsomkostning". Dette for at dette ikke sammenlignes med Energinets balancetarif

Clever Power beskriver omkostningen her: https://intercom.help/cleverdenmark/da/articles/5816968-hvordan-forstar-jeg-min-elregning eller betingelserne punkt 6.1 https://clever.dk/media/tdagjinz/clever-power-vilkaar-19-12-2022-pdf.pdf