### PR TITLE
Add go'energi go'spot energi and go'spot måned

### DIFF
--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -1137,5 +1137,51 @@ export const products = [
 				conditions: 'Ikke bekræftet'
 			}
 		]
+	},
+	{
+		id: 'go_energi_gospot_energi',
+		name: 'go\'energi go\'spot energi',
+		link: 'https://go-energi.dk/elprodukter/til-private/stroem-til-budgetpris/gospot-energi',
+		payments: 'Acontobetaling kvartalsvis',
+		prices: [
+			{
+				name: 'Spotpris',
+				amount: null
+			},
+			{
+				name: 'Fortjeneste, balanceomkostninger, profilomkostninger og handelsomkostninger',
+				amount: 0.05
+			}
+		],
+		fees: [
+			{
+				name: 'Abonnement',
+				amount: 15.00,
+				paymentsPerYear: 12
+			}
+		]
+	},
+	{
+		id: 'go_energi_gospot_maaned',
+		name: 'go\'energi go\'spot måned',
+		link: 'https://go-energi.dk/elprodukter/til-private/stroem-til-budgetpris/gospot-maaned',
+		payments: 'Acontobetaling månedligt',
+		prices: [
+			{
+				name: 'Spotpris',
+				amount: null
+			},
+			{
+				name: 'Fortjeneste, balanceomkostninger, profilomkostninger og handelsomkostninger',
+				amount: 0.05
+			}
+		],
+		fees: [
+			{
+				name: 'Abonnement',
+				amount: 30.00,
+				paymentsPerYear: 12
+			}
+		]
 	}
 ];

--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -1150,13 +1150,13 @@ export const products = [
 			},
 			{
 				name: 'Fortjeneste, balanceomkostninger, profilomkostninger og handelsomkostninger',
-				amount: 0.05
+				amount: 0.04
 			}
 		],
 		fees: [
 			{
 				name: 'Abonnement',
-				amount: 15.00,
+				amount: 12.00,
 				paymentsPerYear: 12
 			}
 		]
@@ -1173,13 +1173,13 @@ export const products = [
 			},
 			{
 				name: 'Fortjeneste, balanceomkostninger, profilomkostninger og handelsomkostninger',
-				amount: 0.05
+				amount: 0.04
 			}
 		],
 		fees: [
 			{
 				name: 'Abonnement',
-				amount: 30.00,
+				amount: 24.00,
 				paymentsPerYear: 12
 			}
 		]

--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -1149,15 +1149,29 @@ export const products = [
 				amount: null
 			},
 			{
-				name: 'Fortjeneste, balanceomkostninger, profilomkostninger og handelsomkostninger',
+				name: 'Tillæg til spotpris',
 				amount: 0.04
 			}
 		],
 		fees: [
 			{
 				name: 'Abonnement',
-				amount: 12.00,
+				amount: 12,
 				paymentsPerYear: 12
+			},
+			{
+				name: 'Rykkergebyr',
+				amount: 100,
+			},
+			{
+				name: 'Betaling via betalingsservice',
+				amount: 0,
+				paymentsPerYear: 4
+			},
+			{
+				name: 'Betaling med indbetalingskort',
+				amount: 0,
+				paymentsPerYear: 4
 			}
 		]
 	},
@@ -1172,15 +1186,29 @@ export const products = [
 				amount: null
 			},
 			{
-				name: 'Fortjeneste, balanceomkostninger, profilomkostninger og handelsomkostninger',
+				name: 'Tillæg til spotpris',
 				amount: 0.04
 			}
 		],
 		fees: [
 			{
 				name: 'Abonnement',
-				amount: 24.00,
+				amount: 24,
 				paymentsPerYear: 12
+			},
+			{
+				name: 'Rykkergebyr',
+				amount: 100,
+			},
+			{
+				name: 'Betaling via betalingsservice',
+				amount: 0,
+				paymentsPerYear: 4
+			},
+			{
+				name: 'Betaling med indbetalingskort',
+				amount: 0,
+				paymentsPerYear: 4
 			}
 		]
 	}

--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -1203,12 +1203,12 @@ export const products = [
 			{
 				name: 'Betaling via betalingsservice',
 				amount: 0,
-				paymentsPerYear: 4
+				paymentsPerYear: 12
 			},
 			{
 				name: 'Betaling med indbetalingskort',
 				amount: 0,
-				paymentsPerYear: 4
+				paymentsPerYear: 12
 			}
 		]
 	}


### PR DESCRIPTION
Added prices for go'spot energi and go'spot måned from go'energi:

- https://go-energi.dk/elprodukter/til-private/stroem-til-budgetpris/gospot-energi
- https://go-energi.dk/elprodukter/til-private/stroem-til-budgetpris/gospot-maaned