### PR TITLE
Update prices.js

### DIFF
--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -288,7 +288,7 @@ export const products = [
 		fees: [
 			{
 				name: 'Abonnement',
-				amount: 0
+				amount: 125,75
 			},
 			{
 				name: 'Omkostning/gebyr pr. regning. ved betaling via netbank.',


### PR DESCRIPTION
Vindstød/dansk vind opkræver pr. kvartal på deres fakturaer kr. 125,75 ex moms på vegne af netselskabet (i vores tilfælde Dinel). Dette beløb bør indgå i den viste pris pr. kWh, når der er sat flueben i "transmission".

[Opkrævning.pdf](https://github.com/rndfm/elspotpris/files/10400701/Opkraevning.pdf)
