### PR TITLE
Updated vindstoed prices to match the listed prices in their website

### DIFF
--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -271,7 +271,7 @@ export const products = [
 			},
 			{
 				name: 'Tillæg til spotpris',
-				amount: 0.005
+				amount: 0.00504
 			}
 		],
 		fees: [
@@ -340,7 +340,7 @@ export const products = [
 			},
 			{
 				name: 'Tillæg til spotpris',
-				amount: 0.005
+				amount: 0.00504
 			}
 		],
 		fees: [


### PR DESCRIPTION
Vindstød is listing the prices on their website as 0.63 øre / kWh for both DanskVind and LokalVind, updated the prices to reflect that.

![Screenshot 2023-02-09 at 09 09 19](https://user-images.githubusercontent.com/5996053/217754060-f8b82694-20fb-4056-b63b-1f49ffa86752.png)
![Screenshot 2023-02-09 at 09 09 28](https://user-images.githubusercontent.com/5996053/217754063-cdba295c-3dc8-49b0-9fd5-434042bb4add.png)
