### PR TITLE
Add Strømlinet Prisgaranti Variabel

### DIFF
--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -1180,6 +1180,36 @@ export const products = [
 		disabled: true
 	},
 	{
+		id: 'stromlinet_prisgaranti',
+		name: 'Strømlinet Prisgaranti Variabel',
+		link: 'https://stromlinet.dk/',
+		payments: 'Acontobetaling kvartalsvis',
+		paymentType: "advance",
+		bindingPeriod: null,
+		prices: [
+			{
+				name: 'Spotpris',
+				amount: null
+			},
+			{
+				name: 'Tillæg til spotpris',
+				amount: 0.11,
+			}
+		],
+		fees: [
+			{
+				name: 'Abonnement',
+				amount: 23.2,
+				paymentsPerYear: 12
+			},
+			{
+				name: 'Betaling via betalingsservice',
+				amount: 6.4,
+				paymentsPerYear: 4
+			}		
+		]
+	},
+	{
 		id: 'energi_viborg',
 		name: 'Energi Viborg',
 		link: 'https://www.energiviborg.dk/stroem/bestil-stroem',


### PR DESCRIPTION
Hej, Jeg har strømlinet og kunne se du manglede priser på dem.

Jeg har noget de kalder Prisgaranti (Variabel) som før var et fastprisprodukt som de har lavet om til variabel, så det hedder derfor ikke det samme som de 2 andre produkter de beskriver på deres hjemmeside, men det skulle være tæt på det samme some deres Vindenergi.

Jeg har regnet deres spotpris tillæg ud til 11 øre ex moms, du kan se udregning på det her google sheet.
https://docs.google.com/spreadsheets/d/1RqQ4jEGpHL6cFqE-dC_HR6_wGx7ZmQojrsdpyu84hS8/edit?usp=sharing

Regningen som der er regnet baglsens fra
![image](https://user-images.githubusercontent.com/26866146/221291736-507a7f18-e48c-4298-ad99-2be74376accf.png)

Jeg er lidt i tvivl om abonnement der er på denne som jeg har da det ser ud til at ændre sig til 2023Q1 men også pga. Radius C målerafgiften er ændret, den er med i den faste på den regning her.