### PR TITLE
Fix elafgift

### DIFF
--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -11,7 +11,7 @@ export const governmentTariffs = [
 		name: 'Elafgift 2023',
 		amount: 0.008,
 		validFrom: "2023-01-01T00:00:00",
-		validTo: "2023-06-01T00:00:00",
+		validTo: "2023-07-01T00:00:00",
 	}
 ];
 

--- a/elspotpris.app/src/prices.js
+++ b/elspotpris.app/src/prices.js
@@ -12,6 +12,13 @@ export const governmentTariffs = [
 		amount: 0.008,
 		validFrom: "2023-01-01T00:00:00",
 		validTo: "2023-07-01T00:00:00",
+	},
+	{
+		id: 'elafgift2023h2',
+		name: 'Elafgift 2023 H2',
+		amount: 0.697,
+		validFrom: "2023-07-01T00:00:00",
+		validTo: "2024-01-01T00:00:00",
 	}
 ];
 


### PR DESCRIPTION
Rettet slutdato for 2023 H1 og inkluderet 2023 H2.
Jf. https://fm.dk/media/26367/faktaark_lempelse-af-elafgift-til-minimumssats-i-seks-maaneder.pdf så får vi ny sats i 2024 så har sat slutdato på 2023 H2.